### PR TITLE
Fix undefined JSONDecodeError

### DIFF
--- a/src/testdrive/asciidoc.py
+++ b/src/testdrive/asciidoc.py
@@ -149,7 +149,7 @@ class TestCase(dict):
         try:
             dct = json.loads(self.stdout)
             timestamp = dct.get('timestamp')
-        except (TypeError, JSONDecodeError, AttributeError):
+        except (TypeError, json.JSONDecodeError, AttributeError):
             return
         if timestamp:
             self._timestamp = timestamp


### PR DESCRIPTION
An incorrectly referenced JSONDecodeError causes the try/catch block to throw a `NameError`.

```
Traceback (most recent call last):
  File "/usr/lib64/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "${TESTDRIVE_PATH}/asciidoc.py", line 474, in <module>
    main()
  File "${TESTDRIVE_PATH}/asciidoc.py", line 460, in main
    suites.include(input_)
  File "${TESTDRIVE_PATH}/asciidoc.py", line 395, in include
    suite = TestSuite(elem)
  File "${TESTDRIVE_PATH}/asciidoc.py", line 300, in __init__
    case = TestCase(child)
  File "${TESTDRIVE_PATH}/asciidoc.py", line 131, in __init__
    self._use_timing_from_stdout()
  File "${TESTDRIVE_PATH}/asciidoc.py", line 152, in _use_timing_from_stdout
    except (TypeError, JSONDecodeError, AttributeError):
NameError: name 'JSONDecodeError' is not defined
```