### PR TITLE
Correctly parse a test case with no properties set

### DIFF
--- a/src/testdrive/asciidoc.py
+++ b/src/testdrive/asciidoc.py
@@ -125,8 +125,10 @@ class TestCase(dict):
         (self._result, self._reason) = self._result_reason_from_elem(elem)
         self._stdout = self._stdout_from_elem(elem)
         # put each property pair into this test case as a dict
-        for child in elem.find('properties').findall('property'):
-            self[child.get('name')] = child.get('value')
+        properties = elem.find('properties')
+        if properties is not None:
+            for child in properties.findall('property'):
+                self[child.get('name')] = child.get('value')
         if not self._timestamp or self._duration is None:
             self._use_timing_from_stdout()
     @staticmethod


### PR DESCRIPTION
This change allows asciidoc.py to continue parsing the JUnit file even if one or more test cases have no 'properties' tag present.

```
Traceback (most recent call last):
  File "/usr/lib64/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "${TESTDRIVE_PATH}/testdrive/asciidoc.py", line 474, in <module>
    main()
  File "${TESTDRIVE_PATH}/testdrive/asciidoc.py", line 460, in main
    suites.include(input_)
  File "${TESTDRIVE_PATH}/testdrive/asciidoc.py", line 395, in include
    suite = TestSuite(elem)
  File "${TESTDRIVE_PATH}/testdrive/asciidoc.py", line 300, in __init__
    case = TestCase(child)
  File "${TESTDRIVE_PATH}/testdrive/asciidoc.py", line 128, in __init__
    for child in elem.find('properties').findall('property'):
AttributeError: 'NoneType' object has no attribute 'findall'
```

---

# The rendered result

When no properties are set on a test case, its identifier is rendered as "not recorded".

![Screenshot from 2023-10-24 11-29-59](https://github.com/redhat-partner-solutions/testdrive/assets/11350965/03e56c94-8bd1-4c9d-8af6-61937f53b6a3)
